### PR TITLE
update pyo3 version to fix build failure in macOS

### DIFF
--- a/enigma_csp/Cargo.toml
+++ b/enigma_csp/Cargo.toml
@@ -25,7 +25,7 @@ getopts = { version = "0.2", optional = true }
 nom = { version = "7.0.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-pyo3 = { version = "0.14.5", features = ["extension-module"] }
+pyo3 = { version = "0.20.2", features = ["extension-module"] }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Building with old version of `pyo3` fails in macos:
```
> RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" cargo build --release
...
   Compiling pyo3-macros v0.14.5
error[E0425]: cannot find function, tuple struct or tuple variant `PyUnicode_READY` in module `ffi`
   --> /Users/akita/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.14.5/src/types/string.rs:234:30
    |
234 |             let ready = ffi::PyUnicode_READY(ptr);
    |                              ^^^^^^^^^^^^^^^ help: a function with a similar name exists: `PyUnicode_IS_READY`
    |
   ::: /Users/akita/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.14.5/src/ffi/cpython/unicodeobject.rs:224:1
    |
224 | pub unsafe fn PyUnicode_IS_READY(op: *mut PyObject) -> c_uint {
    | ------------------------------------------------------------- similarly named function `PyUnicode_IS_READY` defined here

For more information about this error, try `rustc --explain E0425`.
error: could not compile `pyo3` (lib) due to previous error
```

This is because the `ffi` crate's `PyUnicode_READY` is currently `PyUnicode_IS_READY`, so use the latest version.

Test seems to be okay:
```
> RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" cargo test
...
running 111 tests
test arithmetic::tests::test_div_ceil ... ok
test arithmetic::tests::test_cmp_op_compare ... ok
test arithmetic::tests::test_div_floor ... ok
test backend::glucose::tests::test_solver2 ... ok
test backend::glucose::tests::test_solver ... ok
test csp::tests::test_constant_prop1 ... ok
test csp::tests::test_constant_folding1 ... ok
test backend::glucose::tests::test_custom_constraint_xor1 ... ok
test encoder::tests::test_encode_linear_eq_direct_two_terms ... ok
test backend::glucose::tests::test_custom_constraint_xor3 ... ok
test encoder::tests::test_encode_linear_eq_direct ... ok
test backend::glucose::tests::test_custom_constraint_xor2 ... ok
test encoder::tests::test_encode_linear_eq_log_encoding_1 ... ok
test encoder::tests::test_encode_linear_ge_order_encoding_native ... ok
test encoder::tests::test_encode_linear_ge_mixed ... ok
test encoder::tests::test_encode_log_var ... ok
test encoder::tests::test_encode_linear_ne_direct ... ok
test encoder::tests::test_encode_simple_linear_direct_encoding ... ok
test encoder::tests::test_encode_linear_ne_log_encoding ... ok
test integration::tests::test_integration_bool_lit_after_decomposition ... ok
test integration::tests::test_integration_csp_optimization1 ... ok
test integration::tests::test_integration_csp_optimization2 ... ok
test integration::tests::test_integration_csp_optimization3 ... ok
test encoder::tests::test_encode_mul_log ... ok
test integration::tests::test_integration_domain_list1 ... ok
test integration::tests::test_integration_exhaustive_binary1 ... ok
test integration::tests::test_integration_exhaustive_alldifferent ... ok
test integration::tests::test_integration_exhaustive_binary3 ... ok
test integration::tests::test_integration_exhaustive_binary4 ... ok
test integration::tests::test_integration_exhaustive_bool1 ... ok
test integration::tests::test_integration_active_vertices_connected1 ... ok
test integration::tests::test_integration_exhaustive_circuit2 ... ok
test integration::tests::test_integration_exhaustive_circuit1 ... ok
test integration::tests::test_integration_exhaustive_complex2 ... ok
test integration::tests::test_integration_exhaustive_binary2 ... ok
test integration::tests::test_integration_exhaustive_complex1 ... ok
test integration::tests::test_integration_exhaustive_enumerative1 ... ok
test integration::tests::test_integration_exhaustive_complex3 ... ok
test integration::tests::test_integration_exhaustive_enumerative2 ... ok
test integration::tests::test_integration_exhaustive_enumerative3 ... ok
test integration::tests::test_integration_exhaustive_linear1 ... ok
test encoder::tests::test_encode_linear_ge_log_encoding_1 ... ok
test integration::tests::test_integration_exhaustive_linear2 ... ok
test integration::tests::test_integration_exhaustive_extension_supports1 ... ok
test integration::tests::test_integration_exhaustive_complex4 ... ok
test integration::tests::test_integration_exhaustive_linear3 ... ok
test encoder::tests::test_encode_linear_log_encoding_operators ... ok
test integration::tests::test_integration_graph_division2 ... ok
test integration::tests::test_integration_irrefutable_alldifferent ... ok
test integration::tests::test_integration_irrefutable_complex1 ... ok
test integration::tests::test_integration_irrefutable_complex2 ... ok
test integration::tests::test_integration_irrefutable_logic1 ... ok
test integration::tests::test_integration_perf_stats ... ok
test integration::tests::test_integration_seed ... ok
test integration::tests::test_integration_simple_alldifferent ... ok
test integration::tests::test_integration_simple_linear1 ... ok
test integration::tests::test_integration_simple_linear2 ... ok
test integration::tests::test_integration_simple_linear3 ... ok
test integration::tests::test_integration_simple_linear4 ... ok
test integration::tests::test_integration_simple_linear5 ... ok
test integration::tests::test_integration_exhaustive_mul1 ... ok
test integration::tests::test_integration_simple_logic1 ... ok
test integration::tests::test_integration_simple_logic2 ... ok
test integration::tests::test_integration_simple_logic3 ... ok
test integration::tests::test_integration_simple_logic4 ... ok
test integration::tests::test_integration_solve_twice ... ok
test integration::tests::test_integration_solver_iterator ... ok
test integration::tests::test_integration_unused_bool ... ok
test integration::tests::test_integration_unused_int ... ok
test integration::tests::test_integration_unused_then_used_bool ... ok
test norm_csp::tests::test_norm_csp_refinement1 ... ok
test norm_csp::tests::test_norm_csp_refinement2 ... ok
test norm_csp::tests::test_norm_csp_refinement3 ... ok
test normalizer::tests::test_normalization_alldifferent ... ok
test normalizer::tests::test_normalization_and ... ok
test normalizer::tests::test_normalization_abs ... ok
test normalizer::tests::test_normalization_empty ... ok
test normalizer::tests::test_normalization_equiv_optimization ... ok
test normalizer::tests::test_normalization_extension_supports_1 ... ok
test normalizer::tests::test_normalization_extension_supports_2 ... ok
test normalizer::tests::test_normalization_if ... ok
test normalizer::tests::test_normalization_iff ... ok
test normalizer::tests::test_normalization_imp ... ok
test normalizer::tests::test_normalization_linear_1 ... ok
test normalizer::tests::test_normalization_linear_2 ... ok
test normalizer::tests::test_normalization_logic_complex1 ... ok
test normalizer::tests::test_normalization_logic_complex2 ... ok
test normalizer::tests::test_normalization_many_xor ... ok
test normalizer::tests::test_normalization_mul ... ok
test normalizer::tests::test_normalization_not ... ok
test normalizer::tests::test_normalization_numeral ... ok
test normalizer::tests::test_normalization_or ... ok
test normalizer::tests::test_normalization_xor1 ... ok
test normalizer::tests::test_normalization_xor2 ... ok
test normalizer::tests::test_normalization_xor_constant ... ok
test parser::tests::test_parser_parser ... ok
test parser::tests::test_parser_syntax_tree ... ok
test test_util::tests::test_check_active_vertices_connected ... ok
test test_util::tests::test_product_binary1 ... ok
test test_util::tests::test_product_binary2 ... ok
test test_util::tests::test_product_multi1 ... ok
test test_util::tests::test_product_multi2 ... ok
test test_util::tests::test_product_multi3 ... ok
test test_util::tests::test_product_multi4 ... ok
test integration::tests::test_integration_irrefutable_many_terms ... ok
test integration::tests::test_integration_graph_division1 ... ok
test encoder::tests::test_encode_linear_eq_log_encoding_3 ... ok
test encoder::tests::test_encode_linear_ge_log_encoding_2 ... ok
test encoder::tests::test_encode_linear_eq_log_encoding_2 ... ok
test normalizer::tests::test_normalization_circuit_1 ... ok
test integration::tests::test_integration_exhaustive_mul2 ... ok

test result: ok. 111 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.13s
```