### PR TITLE
Fixed edges for shugaku

### DIFF
--- a/cspuz_solver_backend/src/puzzle/school_trip.rs
+++ b/cspuz_solver_backend/src/puzzle/school_trip.rs
@@ -33,8 +33,8 @@ pub fn solve(url: &str) -> Result<Board, &'static str> {
                 if (is_black[y][x] == Some(false) && problem[y][x] == None) || (is_black[y + 1][x] == Some(false) && problem[y + 1][x] == None) { 
                     // If a cell is not black in the solution then either it is a number in the problem, or a futon. This checks which cells are futons                                                                                                                                        
                     board.push(Item {
-                        y: y * 2 + 1,
-                        x: x * 2 + 2,
+                        y: y * 2 + 2,
+                        x: x * 2 + 1,
                         color: if is_connected.vertical[y][x].is_some() {
                             "green"
                         } else {
@@ -54,8 +54,8 @@ pub fn solve(url: &str) -> Result<Board, &'static str> {
                 if (is_black[y][x] == Some(false) && problem[y][x] == None) || (is_black[y][x + 1] == Some(false) && problem[y][x + 1] == None) { 
                     // If a cell is not black in the solution then either it is a number in the problem, or a futon. This checks which cells are futons                                                                                                                                        
                     board.push(Item {
-                        y: y * 2 + 2,
-                        x: x * 2 + 1,
+                        y: y * 2 + 1,
+                        x: x * 2 + 2,
                         color: if is_connected.horizontal[y][x].is_some() {
                             "green"
                         } else {


### PR DESCRIPTION
Previously, `ItemKind:BoldWall` was put everywhere on the grid the futons were not connected, including between connected black cells. This fixes this by drawing edges only if one of the two cells of the edge is part of a futon in the solution. 