### PR TITLE
Fix nuritwin with 1x1 region

### DIFF
--- a/cspuz_rs_puzzles/src/puzzles/nuritwin.rs
+++ b/cspuz_rs_puzzles/src/puzzles/nuritwin.rs
@@ -29,7 +29,7 @@ pub fn solve_nuritwin(
     assert_eq!(rooms.len(), clues.len());
 
     for i in 0..rooms.len() {
-        if (rooms[i].len() as i32) == 1 {
+        if (rooms[i].len() as i32) < 3 {
             return None;
         }
         let block_size = &solver.int_var(1, (rooms[i].len() as i32) / 2);

--- a/cspuz_rs_puzzles/src/puzzles/nuritwin.rs
+++ b/cspuz_rs_puzzles/src/puzzles/nuritwin.rs
@@ -29,6 +29,9 @@ pub fn solve_nuritwin(
     assert_eq!(rooms.len(), clues.len());
 
     for i in 0..rooms.len() {
+        if (rooms[i].len() as i32) == 1 {
+            return None;
+        }
         let block_size = &solver.int_var(1, (rooms[i].len() as i32) / 2);
         if let Some(n) = clues[i] {
             solver.add_expr(block_size.eq(n));


### PR DESCRIPTION
If a puzzle has a 1x1 region, the solver crashes. This prevents this as well as providing a small improvement