### PR TITLE
use -fPIC flag for building Glucose for wasm32 target

### DIFF
--- a/cspuz_core/build.rs
+++ b/cspuz_core/build.rs
@@ -45,6 +45,7 @@ fn build_glucose() {
             .include("lib/glucose")
             .flag("-DGLUCOSE_FIX_OPTIONS")
             .flag("-DGLUCOSE_UNUSE_STDIO")
+            .flag("-fPIC")
             .flag(puzzle_solver_minimal_flag)
             .warnings(false)
             .compile("calc");


### PR DESCRIPTION
fix failure https://github.com/semiexp/cspuz_core/actions/runs/24843872375/job/72725518142?pr=232